### PR TITLE
Add xlarge icon size

### DIFF
--- a/ui/components/icons/base/_index.scss
+++ b/ui/components/icons/base/_index.scss
@@ -244,7 +244,7 @@ $bg-standard-map: map-merge($task2-monkey-patch, $bg-standard-map);
  * @group color
  */
 .slds-icon-text-cash_loan {
-  fill: $color-text-cashloan;
+  fill: $color-text-cash-loan;
 }
 
 /**


### PR DESCRIPTION
If applied, `x-large` as icon size will be available and can be specified as prop to SvgIcon as `size="x-large"`